### PR TITLE
Bump angular version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,9 +11,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.20"
+    "angular": "~1.x"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.20"
+    "angular-mocks": "~1.x"
   }
 }


### PR DESCRIPTION
Presuming ng-disabled doesn't change in future updates to Angular 1, it would be better to allow all versions of Angular.
